### PR TITLE
Add macOS and Linux testing support via GitHub Actions

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -17,7 +17,10 @@ defaults:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1
         with:

--- a/.github/workflows/nim.yml
+++ b/.github/workflows/nim.yml
@@ -1,0 +1,36 @@
+name: nim
+
+on:
+  push:
+    branches: main 
+    paths:
+      - 'nim/**'
+      - '.github/workflows/nim.yml'
+      - 'triplets.nimble'
+      
+defaults:
+  run:
+    working-directory: nim
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: jiro4989/setup-nim-action@v1
+        with:
+          nim-version: 'stable'
+      - name: Install dependencies
+        run: nimble install -y
+      - name: Run tests
+        run: |
+          cd tests
+          for test in test*.nim; do
+            echo "Running $test"
+            nim c -r "$test"
+          done

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,29 @@
+name: rust
+
+on:
+  push:
+    branches: main 
+    paths:
+      - 'rust/**'
+      - '.github/workflows/rust.yml'
+      
+defaults:
+  run:
+    working-directory: rust
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Run tests
+        run: cargo test --release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Data.Triplets/issues/34
+Your prepared branch: issue-34-d1e9959e
+Your prepared working directory: /tmp/gh-issue-solver-1757790192910
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Data.Triplets/issues/34
-Your prepared branch: issue-34-d1e9959e
-Your prepared working directory: /tmp/gh-issue-solver-1757790192910
-
-Proceed.


### PR DESCRIPTION
## Summary
- Updated existing C# workflow to test on both Ubuntu and macOS using matrix strategy
- Created new Nim workflow with multi-OS testing for nim projects
- Created new Rust workflow with multi-OS testing for rust projects  
- All workflows now test on Linux (ubuntu-latest) and macOS (macos-latest)

## Changes Made
1. **C# Workflow (`csharp.yml`)**: Modified the existing test job to use a matrix strategy with `[ubuntu-latest, macos-latest]`
2. **Nim Workflow (`nim.yml`)**: New workflow that runs Nim tests on both operating systems
3. **Rust Workflow (`rust.yml`)**: New workflow that runs Rust tests on both operating systems

## Test Plan
- [x] All workflows use matrix strategy for multi-OS testing
- [x] Workflows trigger on pushes to main branch and relevant path changes
- [x] Workflows use appropriate setup actions for each language/OS combination
- [x] Each workflow preserves existing functionality while adding macOS support

This resolves issue #34 by ensuring all three language implementations (C#, Nim, Rust) are tested on both macOS and Linux machines using GitHub Actions.

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #34